### PR TITLE
docs: Improve README with project details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+This document includes some guidelines for contributing to the project.
+
+## 🚧 Committing
+
+This project uses the [Conventional Commits](https://www.conventionalcommits.org/) specification. This means that commit messages must adhere to the specification, so that they stay consistent and can be used to automatically generate change logs when releasing new versions.
+
+The following types of commits are supported:
+
+- `build`: Changes that affect the build system or external dependencies.
+- `ci`: Changes to the CI configuration files and scripts.
+- `docs`: Documentation only changes.
+- `chore`: Common tasks that do not need to be tracked, i.e. update dependencies.
+- `feat`: A new feature.
+- `fix`: A bug fix.
+- `perf`: A code change that improves performance.
+- `refactor`: A code change that neither fixes a bug nor adds a feature.
+- `revert`: Revert a previous commit
+- `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
+- `test`: Adding missing tests or correcting existing tests.
+
+Any breaking changes that are introduced during development need to be tracked in the commit message. To do so, we need to add a bang (`!`) to the type of commit (e.g. `feat!`) and `BREAKING CHANGES:` as part of the commit message:
+
+```
+feat!: Breaking something
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+This will result in this changelog:
+
+```
+### ⚠ BREAKING CHANGES
+* `extends` key in config file is now used for extending other config files.
+### Features
+* Breaking something
+```
+
+### Rules
+
+The commits are checked and validated using [`commitlint`](https://github.com/conventional-changelog/commitlint). The linter can be configured to some extent but there are some things that need to be documented in order to keep the commit history as clean and as consistent as possible:
+
+- Commits must be prefixed with a type. The supported types are listed in the above section.
+- Breaking changes must be indicated in the type of a commit.
+- Subjects must use sentence-case.
+- Subjects must use imperative tense, as if issuing a command or making a request.
+- Commits should have a body explaining why they are needed, what they are doing and how.
+
+## 🔀 Pull Requests
+
+Pull requests should have a clear scope and be concise. When applicable, include screenshots that better demonstrate the newly introduced features or bug fixes.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,51 @@
 # Bank UI
 
-UI for the Bank application.
+[![codecov](https://codecov.io/gh/ricardocosta/bank-ui/branch/main/graph/badge.svg?token=T5FJHNAKPA)](https://codecov.io/gh/ricardocosta/bank-ui)
+
+[Nx](https://nx.dev/) monorepo for the Bank project UI.
+
+## 🗂 Structure
+
+- The `apps` directory contains all the apps and correspondent E2E tests.
+- The `tools` directory contains generic tooling and scripts that can be used through the project.
 
 ## 🔌 Running
 
-You can run the application locally with:
+The apps have a set of targets configured, depending on the app type. \
+Check the `project.json` file in each app to see the details, including the value of `<app-name>`.
 
-```
-$ yarn dev
-```
+Run a target with:
+`yarn nx run <app-name>:<target>`
 
-The application will be available at [http://localhost:3000/](http://localhost:3000/).
+Example:
+`yarn nx run apps/sandbox:lint`
 
+**Regular Apps**
 
-## 📦 Publishing
+| Target         | Description                                     |
+| :------------- | :---------------------------------------------- |
+| `build`        | Build the application.                          |
+| `dev`          | Run the application in dev mode.                |
+| `preview`      | Locally preview production build.               |
+| `test`         | Run the test.                                   |
+| `testCoverage` | Run the tests generating a coverage report.     |
+| `testUi`       | Run the tests with the UI dashboard.            |
+| `testWatch`    | Run the tests in watch mode.                    |
+| `lint`         | Lint the application with ESLint.               |
+| `format`       | Format the application with Prettier.           |
+| `formatDry`    | Check if the application is properly formatted. |
+| `ts`           | Check if the application is compiling.          |
+| `seedDb`       | Generate a seed DB for a local REST server.     |
 
-To publish a new version of the project:
+**E2E Apps**
 
-1. Create a branch for the release:
+| Target    | Description                         |
+| :-------- | :---------------------------------- |
+| `e2e`     | Run the E2E tests.                  |
+| `codegen` | Launch Playwright's code generator. |
 
-```
-$ git checkout -b release_$(date -u +"%Y%m%d")
-```
+## Coverage
 
-2. Preview the changes to `CHANGELOG` and predicted tag:
+This project is configured with Codecov to automatically check if Pull Requests keep code coverage levels.
 
-```
-$ yarn run release:dry
-```
-
-3. Update the `CHANGELOG` file automatically based on the commits:
-
-```
-$ yarn run release
-```
-
-4. Open a Pull Request against `main` and have it merged.
-
-5. Update your local `main` branch, generate the new tag and push it:
-
-```
-$ git checkout main
-$ git pull
-$ yarn release:tag
-$ git push --tags
-```
+<img src="https://codecov.io/gh/ricardocosta/bank-ui/branch/main/graphs/icicle.svg?token=T5FJHNAKPA" alt="Current code coverage">


### PR DESCRIPTION

## Summary

Improve the README file with project details and available targets for the apps and e2e tests.
A CONTRIBUTING guide has also been added with details around the commit strategy and conventions.

Closes #26
