### PR TITLE
chore: Use Vitest globals instead of Jest

### DIFF
--- a/apps/sandbox/setupTests.ts
+++ b/apps/sandbox/setupTests.ts
@@ -1,1 +1,11 @@
-import "@testing-library/jest-dom";
+import matchers, { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
+
+declare global {
+  namespace Vi {
+    interface JestAssertion<T = any>
+      extends jest.Matchers<void, T>,
+        TestingLibraryMatchers<T, void> {}
+  }
+}
+
+expect.extend(matchers);

--- a/apps/sandbox/tsconfig.json
+++ b/apps/sandbox/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["vitest/globals"]
   }
 }


### PR DESCRIPTION


## Summary

Properly configure tests to use Vitest globals (e.g. describe) and still keep jest-dom's features.
<!-- Summary of the proposed changes -->

<!-- Include screenshots or recording to better describe the proposed changes -->

## Testing

<!-- Instructions on how to test the changes -->

## Other Information

**Breaking Changes [YES / NO]** <!-- Whether or not this PR introduces breaking changes -->
**Affected Component** <!-- Which of the components is affected by this change -->
