### PR TITLE
chore: Allow URLs to go over line lengh limit

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,8 +1,22 @@
+const MAX_BODY_LINE_LENGTH = 100;
+
+const lineLengthValidator = (arg) => {
+  const urlRegex = /https?:\/\//gi;
+  const linesAboveLimit = (arg ?? "")
+    .split("\n")
+    .filter((line) => line.length > MAX_BODY_LINE_LENGTH);
+
+  return [
+    linesAboveLimit.every((line) => line.match(urlRegex)) ? 2 : 0,
+    `Commit message contains lines above the ${MAX_BODY_LINE_LENGTH} characters limit.`,
+  ];
+};
+
 module.exports = {
   extends: ["@commitlint/config-conventional", "@commitlint/config-nx-scopes"],
   rules: {
     "subject-case": [2, "always", "sentence-case"],
-    "body-max-line-length": [2, "always", 80],
+    "body-max-line-length": [2, "always", 100],
     "type-enum": [
       2,
       "always",
@@ -21,4 +35,12 @@ module.exports = {
       ],
     ],
   },
+  plugins: [
+    {
+      rules: {
+        "body-max-line-length": ({ body }) => lineLengthValidator(body),
+        "footer-max-line-length": ({ footer }) => lineLengthValidator(footer),
+      },
+    },
+  ],
 };


### PR DESCRIPTION

## Summary

Add a new local plugin to Commitlint that allows lines to be over the defined limit if they contain URLs, defined as containing http(s). This will allow adding links to release notes and other interesting web pages without breaking commitlint rules


<!-- Summary of the proposed changes -->

<!-- Include screenshots or recording to better describe the proposed changes -->

## Testing

<!-- Instructions on how to test the changes -->

## Other Information

**Breaking Changes [YES / NO]** <!-- Whether or not this PR introduces breaking changes -->
**Affected Component** <!-- Which of the components is affected by this change -->
