### PR TITLE
feat(ui-icons): Remove React icons dependency

### DIFF
--- a/libs/ui/ui-icons/README.md
+++ b/libs/ui/ui-icons/README.md
@@ -12,20 +12,20 @@ There are multiple ways to use icons:
 
 ⚠️ Avoid passing `onClick` handlers to the `Icon` component. If you need a clickable icon, use the `IconButton` instead.
 
-To use third-party icon libraries like `react-icons`, here are the steps:
+To use third-party icon libraries like `@emotion-icons/remix-fill`, here are the steps:
 
 1. Import the `Icon` component from `@ricardocosta/ui-icons`
 2. Pass the desired third party icon into the `as` prop
 
 ```tsx
+import { Dashboard } from "@emotion-icons/remix-fill";
 import { Icon, PhoneIcon } from "@ricardocosta/ui-icons";
-import { MdSettings } from "react-icons/md";
 
 // Basic usage with ChakraUI icons
 <PhoneIcon />;
 
-// With react-icons
-<Icon as={MdSettings} />;
+// With @emotion-icons/remix-fill
+<Icon as={Dashboard} />;
 ```
 
 [🔗 ChakraUI Icon](https://chakra-ui.com/docs/components/icon)

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
-    "react-icons": "^4.7.1",
     "react-router-dom": "^6.9.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7066,7 +7066,6 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-helmet-async: ^1.3.0
-    react-icons: ^4.7.1
     react-router-dom: ^6.9.0
     rollup-plugin-exclude-dependencies-from-bundle: ^1.1.23
     standard-version: ^9.5.0
@@ -15645,15 +15644,6 @@ __metadata:
     react: ^16.6.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
   checksum: 7ca7e47f8af14ea186688b512a87ab912bf6041312b297f92516341b140b3f0f8aedf5a44d226d99e69ed067b0cc106e38aeb9c9b738ffcc63d10721c844db90
-  languageName: node
-  linkType: hard
-
-"react-icons@npm:^4.7.1":
-  version: 4.7.1
-  resolution: "react-icons@npm:4.7.1"
-  peerDependencies:
-    react: "*"
-  checksum: ed3cbdc5fc0c4d7d2debf78fdc8c4c80aeacf85a506a9a3c11b1d5922de393ac0a6542012b7fb81761e9280c54d0f26827d50a92b54ec8f0c8e52364d89970b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


## Summary

We are no longer using React Icons as the library for icons, so the dependency can be removed.

<!-- Summary of the proposed changes -->

<!-- Include screenshots or recording to better describe the proposed changes -->

## Testing

<!-- Instructions on how to test the changes -->

## Other Information

**Breaking Changes [YES / NO]** <!-- Whether or not this PR introduces breaking changes -->
**Affected Component** <!-- Which of the components is affected by this change -->
